### PR TITLE
Fix ABM network simulation folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # stata-python-julia-demo
 Codex环境测试用 -A cross-language research environment using Stata, Python, and Julia for Codex deployment.
+
+## Contents
+
+- `abm_network_simulation/` – Python-based agent-based modeling example.
+- `julia/` – Julia project environment.
+- `r/` – R setup script.
+- `stata/` – Stata initialization script.

--- a/abm_network_simulation/README.md
+++ b/abm_network_simulation/README.md
@@ -1,0 +1,21 @@
+# ABM Network Simulation
+
+This folder contains a Python script for running a simple agent-based model (ABM) on network structures. Originally it was saved with a `.ipynb` extension but only contained plain Python code, so it has been renamed to `culture_gene_network_abm.py`.
+
+## Requirements
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the script directly with Python:
+
+```bash
+python culture_gene_network_abm.py
+```
+
+The script will generate simulation results and a CSV output file.

--- a/abm_network_simulation/culture_gene_network_abm.py
+++ b/abm_network_simulation/culture_gene_network_abm.py
@@ -1,7 +1,7 @@
 # Step 1: 环境搭建与工具库导入
 
 # 安装必要工具库（如果是Jupyter/Colab环境，直接运行此行即可。如果是在命令行，去掉 '!'）
-!pip install networkx mesa matplotlib seaborn pandas
+# pip install networkx mesa matplotlib seaborn pandas
 
 # 导入必要工具库
 import networkx as nx

--- a/abm_network_simulation/requirements.txt
+++ b/abm_network_simulation/requirements.txt
@@ -1,0 +1,5 @@
+networkx
+mesa
+matplotlib
+seaborn
+pandas


### PR DESCRIPTION
## Summary
- rename plain text ABM script from `.ipynb` to `.py`
- document simulation usage and requirements
- reference ABM simulation folder in the main README

## Testing
- `python -m py_compile abm_network_simulation/culture_gene_network_abm.py`

------
https://chatgpt.com/codex/tasks/task_e_687de29c4dec832da43ee2ae5c6c5374