### PR TITLE
Add networkx and mesa

### DIFF
--- a/.devcontainer/python/requirements.txt
+++ b/.devcontainer/python/requirements.txt
@@ -7,3 +7,5 @@ statsmodels
 seaborn
 jupyter
 openpyxl
+networkx
+mesa


### PR DESCRIPTION
## Summary
- install `networkx` and `mesa` by default in the devcontainer

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885dfbee860832dac99556b9c8cced1